### PR TITLE
Added Xml support

### DIFF
--- a/contract.json
+++ b/contract.json
@@ -78,6 +78,64 @@
           }
         }
       ]
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "/hello/xml",
+        "contentType": "application/xml"
+      },
+      "responses": [
+        {
+          "condition": null,
+          "status": 200,
+          "fixedDelayMilliseconds": 5000,
+          "body": "string content",
+
+          "jsonBody": {
+            "status": "Success",
+            "message": "Successful response body"
+          },
+          "headers": {
+            "Content-Type": "application/xml"
+          }
+        },
+        {
+          "condition": {
+            "body": {
+              "name": "bar",
+              "surname": "foo"
+            }
+          },
+          "status": 401,
+          "fixedDelayMilliseconds": 5000,
+          "body": "string content",
+          "jsonBody": {
+            "status": "Bad Request",
+            "message": "Bar foo is not authenticated"
+          },
+          "headers": {
+            "Content-Type": "application/xml"
+          }
+        },
+        {
+          "condition": {
+            "body": {
+              "name": "bar"
+            }
+          },
+          "status": 404,
+          "fixedDelayMilliseconds": 5000,
+          "body": "string content",
+          "jsonBody": {
+            "status": "Bad Request",
+            "message": "foo not found!"
+          },
+          "headers": {
+            "Content-Type": "application/xml"
+          }
+        }
+      ]
     }
   ],
   "credentials": {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module gomock-server
 
 go 1.13
+
+require (
+	github.com/basgys/goxml2json v1.1.0
+	github.com/clbanning/anyxml v1.2.2
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/basgys/goxml2json v1.1.0 h1:4ln5i4rseYfXNd86lGEB+Vi652IsIXIvggKM/BhUKVw=
+github.com/basgys/goxml2json v1.1.0/go.mod h1:wH7a5Np/Q4QoECFIU8zTQlZwZkrilY0itPfecMw41Dw=
+github.com/clbanning/anyxml v1.2.2 h1:EqBXr26KEC7tuGLDH7ZSeFmaE3yft0h386m5uydpNbU=
+github.com/clbanning/anyxml v1.2.2/go.mod h1:m8+zXuK8aS9lnXzfpSLUUjXoqcZ41osGX+JXr09eOjY=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Added XML support. Changes;

- [x] Added contentType to request contract to get content type
- [x] When contentType is application/xml then deserialized xml into map[string] interface. So all condition logic etc. working. PS: Still we are using json in mappings.
- [ ] Return XML response when contentType is not working well, yet. 